### PR TITLE
fix: grep false positive in cleanup_orphans.sh

### DIFF
--- a/cPanel/cleanup_orphans.sh
+++ b/cPanel/cleanup_orphans.sh
@@ -152,6 +152,9 @@ handle_orphaned_processes()
     # username 3879283  0.0  0.0  13444  4356 pts/0    S    10:04   0:00 /bin/bash -l
     # username 3911293  0.0  0.0 1086604 73900 ?       Sl   10:11   0:00 lsnode:/home/username/dev.mydomain.com/
     do
+        # avoid matching the actual 'grep' command
+        echo "$line" | grep -q "[g]rep" && continue
+
         # latest process is the active one, keep it alive by only removing 'prev' processes 
         if [ "$prev_line" != "" ]; then
             [ "$verbose" == "1" ] && echo "process: $prev_line"


### PR DESCRIPTION
Thanks for this - came across it whilst investigating why there seemed to be orphaned nodejs processes running in cPanel

An issue I ran into was that the process list from `ps -aux` included the `grep ${SEARCHSTR}` command itself - so if there were no actual orphaned processes then the script would mistakenly identify and kill the legitimate nodejs process, thinking the grep process was one

Adding this line resolved my issue